### PR TITLE
Add Linux support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
-CURA_CONFIG_ROOT="$HOME/Library/Application Support/cura"
-[ -d "$CURA_CONFIG_ROOT" ] && CURA_DIR=`find "$CURA_CONFIG_ROOT" -type d -depth 1 | grep -E "/[0-9]+\.[0-9]+$" | sort | tail -n 1`
+case "$(uname -s)" in
+    Linux*) CURA_CONFIG_ROOT="$HOME/.local/share/cura";;
+    Darwin*) CURA_CONFIG_ROOT="$HOME/Library/Application Support/cura";;
+esac
+
+[ -d "$CURA_CONFIG_ROOT" ] && CURA_DIR=$(find "$CURA_CONFIG_ROOT" -maxdepth 1 -type d | grep -E "/[0-9]+\.[0-9]+$" | sort | tail -n 1)
 
 if [ -z "$CURA_DIR" ]
 then
     echo "Can't find Cura configuration, aborting"
-    exit -1
+    exit 1
 fi
 
 echo "Found Cura configuration directory at $CURA_DIR"


### PR DESCRIPTION
Since me and perhaps some other people might want to use this script on Linux, I added support for it.

I also analyzed your script using `shellcheck`. It reported that exit codes should have a value from 0-255. I corrected this.