### PR TITLE
Update creator_pro.def.json

### DIFF
--- a/resources/definitions/creator_pro.def.json
+++ b/resources/definitions/creator_pro.def.json
@@ -1,6 +1,6 @@
 {
     "id": "creator_pro",
-    "name": "Flashforge Creator Pro",
+    "name": "Creator Pro",
     "version": 2,
     "inherits": "fdmprinter",
     "metadata": {


### PR DESCRIPTION
Please change the parameter  "name": "Creator Pro",

otherwise if you add the profile to curo 4.10 it would not see the printer profile as it somehow collides with the added Dreamer NX also Made by Flashforge...
https://github.com/eugr/Flashforge-for-Cura/issues/19