### PR TITLE
Update creator_pro.def.json

### DIFF
--- a/resources/definitions/creator_pro.def.json
+++ b/resources/definitions/creator_pro.def.json
@@ -6,7 +6,7 @@
     "metadata": {
         "visible": true,
         "author": "Eugr",
-        "manufacturer": "FlashForge",
+        "manufacturer": "Flashforge",
         "platform": "FlashForge_CreatorPro.stl",
         "machine_x3g_variant": "fcp",
         "file_formats": "application/x3g",


### PR DESCRIPTION
Please change line 9 to
        "manufacturer": "Flashforge",
If you look in Cura 4.10 in the file:
flashforge_dreamer_nx.def.json
the line 8 reads
        "manufacturer": "Flashforge",

so small f or it wont see the printer with newly added Flashforge Dreamer NX profile in place after installation.. yours gets the shorter stick and is hidden.

Only revealed by renaming it to  flashforge_dreamer_nx.def.json .old